### PR TITLE
Update AI translation endpoints to Gemini

### DIFF
--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -15,7 +15,7 @@
 // @connect      api.interpreter.caiyunai.com
 // @connect      translate.google.com
 // @connect      openai.api2d.net
-// @connect      api.openai.com
+// @connect      generativelanguage.googleapis.com
 // @connect      www.luogu.com.cn
 // @connect      vjudge.net
 // @connect      clist.by
@@ -6690,7 +6690,7 @@ const chatgptConfigEditHTML = `
                     </div>
                 </div>
             </label>
-            <input type='text' id='chatgpt_model' placeholder='gpt-3.5-turbo' require = false>
+            <input type='text' id='chatgpt_model' placeholder='gemini-2.0-flash' require = false>
         </div>
         <div class="OJBetter_setting_list">
             <label for='chatgpt_key'>
@@ -6714,7 +6714,7 @@ const chatgptConfigEditHTML = `
                     </div>
                 </div>
             </label>
-            <input type='text' id='chatgpt_proxy' placeholder='https://api.openai.com/v1/chat/completions' require = false>
+            <input type='text' id='chatgpt_proxy' placeholder='https://generativelanguage.googleapis.com/v1beta/openai/chat/completions' require = false>
         </div>
         <hr>
         <details>
@@ -13964,7 +13964,7 @@ async function translate_caiyun(raw) {
  * @returns {Promise<TransRawData>} 翻译结果对象
  */
 async function translate_openai(raw) {
-    const modelDefault = 'gpt-3.5-turbo';
+    const modelDefault = 'gemini-2.0-flash';
     const lang = getTargetLanguage('openai');
     let prompt = "";
     if (OJBetter.chatgpt.customPrompt) {
@@ -14012,7 +14012,7 @@ ${raw}
     };
     const options = {
         method: "POST",
-        url: OJBetter.chatgpt.config.proxy || 'https://api.openai.com/v1/chat/completions',
+        url: OJBetter.chatgpt.config.proxy || 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
         data: JSON.stringify(data),
         responseType: 'json',
         headers: {
@@ -14071,7 +14071,7 @@ async function translate_openai_stream(raw, translateDiv) {
  * @returns {AsyncGenerator<string>} 返回 AsyncGenerator
  */
 async function* openai_stream(raw) {
-    const modelDefault = 'gpt-3.5-turbo';
+    const modelDefault = 'gemini-2.0-flash';
     const lang = getTargetLanguage('openai');
     let prompt = "";
     if (OJBetter.chatgpt.customPrompt) {
@@ -14120,7 +14120,7 @@ ${raw}
     };
     const options = {
         method: "POST",
-        url: OJBetter.chatgpt.config.proxy || 'https://api.openai.com/v1/chat/completions',
+        url: OJBetter.chatgpt.config.proxy || 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
         data: JSON.stringify(data),
         responseType: 'stream',
         headers: {

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -15,7 +15,7 @@
 // @connect      api.interpreter.caiyunai.com
 // @connect      translate.google.com
 // @connect      openai.api2d.net
-// @connect      api.openai.com
+// @connect      generativelanguage.googleapis.com
 // @connect      www.luogu.com.cn
 // @connect      vjudge.net
 // @connect      clist.by
@@ -7343,7 +7343,7 @@ const chatgptConfigEditHTML = `
                     </div>
                 </div>
             </label>
-            <input type='text' id='chatgpt_model' placeholder='gpt-3.5-turbo' require = false>
+            <input type='text' id='chatgpt_model' placeholder='gemini-2.0-flash' require = false>
         </div>
         <div class="OJBetter_setting_list">
             <label for='chatgpt_key'>
@@ -7367,7 +7367,7 @@ const chatgptConfigEditHTML = `
                     </div>
                 </div>
             </label>
-            <input type='text' id='chatgpt_proxy' placeholder='https://api.openai.com/v1/chat/completions' require = false>
+            <input type='text' id='chatgpt_proxy' placeholder='https://generativelanguage.googleapis.com/v1beta/openai/chat/completions' require = false>
         </div>
         <hr>
         <details>
@@ -16620,7 +16620,7 @@ async function translate_caiyun(raw) {
  * @returns {Promise<TransRawData>} 翻译结果对象
  */
 async function translate_openai(raw) {
-  const modelDefault = "gpt-3.5-turbo";
+  const modelDefault = "gemini-2.0-flash";
   const lang = getTargetLanguage("openai");
   let prompt = "";
   if (OJBetter.chatgpt.customPrompt) {
@@ -16670,7 +16670,7 @@ ${raw}
     method: "POST",
     url:
       OJBetter.chatgpt.config.proxy ||
-      "https://api.openai.com/v1/chat/completions",
+      "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
     data: JSON.stringify(data),
     responseType: "json",
     headers: {
@@ -16743,7 +16743,7 @@ async function translate_openai_stream(raw, translateDiv) {
  * @returns {AsyncGenerator<string>} 返回 AsyncGenerator
  */
 async function* openai_stream(raw) {
-  const modelDefault = "gpt-3.5-turbo";
+  const modelDefault = "gemini-2.0-flash";
   const lang = getTargetLanguage("openai");
   let prompt = "";
   if (OJBetter.chatgpt.customPrompt) {
@@ -16794,7 +16794,7 @@ ${raw}
     method: "POST",
     url:
       OJBetter.chatgpt.config.proxy ||
-      "https://api.openai.com/v1/chat/completions",
+      "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
     data: JSON.stringify(data),
     responseType: "stream",
     headers: {

--- a/script/dev/nowcoder-better.user.js
+++ b/script/dev/nowcoder-better.user.js
@@ -9,7 +9,7 @@
 // @connect      m.youdao.com
 // @connect      translate.google.com
 // @connect      openai.api2d.net
-// @connect      api.openai.com
+// @connect      generativelanguage.googleapis.com
 // @connect      www.luogu.com.cn
 // @connect      greasyfork.org
 // @connect      *
@@ -1360,7 +1360,7 @@ const chatgptConfigEditHTML = `
                 </div>
             </div>
         </label>
-        <input type='text' id='openai_model' placeholder='gpt-3.5-turbo' require = false>
+        <input type='text' id='openai_model' placeholder='gemini-2.0-flash' require = false>
         <label for='openai_key'>
             <div style="display: flex;align-items: center;">
                 <span class="input_label">KEY:</span>
@@ -1388,7 +1388,7 @@ const chatgptConfigEditHTML = `
                 </div>
             </div>
         </label>
-        <input type='text' id='openai_proxy' placeholder='https://api.openai.com/v1/chat/completions' require = false>
+        <input type='text' id='openai_proxy' placeholder='https://generativelanguage.googleapis.com/v1beta/openai/chat/completions' require = false>
         <h5>高级</h5>
         <hr>
         <label for='_header'>
@@ -2344,7 +2344,7 @@ async function translateProblemStatement(text, element_node, button) {
 async function translate_openai(raw) {
     var openai_retext = "";
     var data = {
-        model:  (openai_model !== null && openai_model !== "") ? openai_model : 'gpt-3.5-turbo',
+        model:  (openai_model !== null && openai_model !== "") ? openai_model : 'gemini-2.0-flash',
         messages: [{
             role: "user",
             content: "请将下面的文本翻译为中文，这是一道编程竞赛题描述的一部分，注意术语的翻译，注意保持其中的latex公式不翻译，你只需要回复翻译后的内容即可，不要回复任何其他内容：\n\n" + raw 
@@ -2355,7 +2355,7 @@ async function translate_openai(raw) {
     return new Promise(function (resolve, reject) {
         GM_xmlhttpRequest({
             method: 'POST',
-            url: (openai_proxy !== null && openai_proxy !== "") ? openai_proxy : 'https://api.openai.com/v1/chat/completions',
+            url: (openai_proxy !== null && openai_proxy !== "") ? openai_proxy : 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
 
             data: JSON.stringify(data),
             headers: {

--- a/script/release/atcoder-better.user.js
+++ b/script/release/atcoder-better.user.js
@@ -15,7 +15,7 @@
 // @connect      api.interpreter.caiyunai.com
 // @connect      translate.google.com
 // @connect      openai.api2d.net
-// @connect      api.openai.com
+// @connect      generativelanguage.googleapis.com
 // @connect      www.luogu.com.cn
 // @connect      vjudge.net
 // @connect      clist.by
@@ -6673,7 +6673,7 @@ const chatgptConfigEditHTML = `
                     </div>
                 </div>
             </label>
-            <input type='text' id='chatgpt_model' placeholder='gpt-3.5-turbo' require = false>
+            <input type='text' id='chatgpt_model' placeholder='gemini-2.0-flash' require = false>
         </div>
         <div class="OJBetter_setting_list">
             <label for='chatgpt_key'>
@@ -6697,7 +6697,7 @@ const chatgptConfigEditHTML = `
                     </div>
                 </div>
             </label>
-            <input type='text' id='chatgpt_proxy' placeholder='https://api.openai.com/v1/chat/completions' require = false>
+            <input type='text' id='chatgpt_proxy' placeholder='https://generativelanguage.googleapis.com/v1beta/openai/chat/completions' require = false>
         </div>
         <hr>
         <details>
@@ -13926,7 +13926,7 @@ async function translate_caiyun(raw) {
  * @returns {Promise<TransRawData>} 翻译结果对象
  */
 async function translate_openai(raw) {
-    const modelDefault = 'gpt-3.5-turbo';
+    const modelDefault = 'gemini-2.0-flash';
     const lang = getTargetLanguage('openai');
     let prompt = "";
     if (OJBetter.chatgpt.customPrompt) {
@@ -13974,7 +13974,7 @@ ${raw}
     };
     const options = {
         method: "POST",
-        url: OJBetter.chatgpt.config.proxy || 'https://api.openai.com/v1/chat/completions',
+        url: OJBetter.chatgpt.config.proxy || 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
         data: JSON.stringify(data),
         responseType: 'json',
         headers: {
@@ -14033,7 +14033,7 @@ async function translate_openai_stream(raw, translateDiv) {
  * @returns {AsyncGenerator<string>} 返回 AsyncGenerator
  */
 async function* openai_stream(raw) {
-    const modelDefault = 'gpt-3.5-turbo';
+    const modelDefault = 'gemini-2.0-flash';
     const lang = getTargetLanguage('openai');
     let prompt = "";
     if (OJBetter.chatgpt.customPrompt) {
@@ -14082,7 +14082,7 @@ ${raw}
     };
     const options = {
         method: "POST",
-        url: OJBetter.chatgpt.config.proxy || 'https://api.openai.com/v1/chat/completions',
+        url: OJBetter.chatgpt.config.proxy || 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
         data: JSON.stringify(data),
         responseType: 'stream',
         headers: {

--- a/script/release/codeforces-better.user.js
+++ b/script/release/codeforces-better.user.js
@@ -15,7 +15,7 @@
 // @connect      api.interpreter.caiyunai.com
 // @connect      translate.google.com
 // @connect      openai.api2d.net
-// @connect      api.openai.com
+// @connect      generativelanguage.googleapis.com
 // @connect      www.luogu.com.cn
 // @connect      vjudge.net
 // @connect      clist.by
@@ -7323,7 +7323,7 @@ const chatgptConfigEditHTML = `
                     </div>
                 </div>
             </label>
-            <input type='text' id='chatgpt_model' placeholder='gpt-3.5-turbo' require = false>
+            <input type='text' id='chatgpt_model' placeholder='gemini-2.0-flash' require = false>
         </div>
         <div class="OJBetter_setting_list">
             <label for='chatgpt_key'>
@@ -7347,7 +7347,7 @@ const chatgptConfigEditHTML = `
                     </div>
                 </div>
             </label>
-            <input type='text' id='chatgpt_proxy' placeholder='https://api.openai.com/v1/chat/completions' require = false>
+            <input type='text' id='chatgpt_proxy' placeholder='https://generativelanguage.googleapis.com/v1beta/openai/chat/completions' require = false>
         </div>
         <hr>
         <details>
@@ -16577,7 +16577,7 @@ async function translate_caiyun(raw) {
  * @returns {Promise<TransRawData>} 翻译结果对象
  */
 async function translate_openai(raw) {
-  const modelDefault = "gpt-3.5-turbo";
+  const modelDefault = "gemini-2.0-flash";
   const lang = getTargetLanguage("openai");
   let prompt = "";
   if (OJBetter.chatgpt.customPrompt) {
@@ -16627,7 +16627,7 @@ ${raw}
     method: "POST",
     url:
       OJBetter.chatgpt.config.proxy ||
-      "https://api.openai.com/v1/chat/completions",
+      "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
     data: JSON.stringify(data),
     responseType: "json",
     headers: {
@@ -16700,7 +16700,7 @@ async function translate_openai_stream(raw, translateDiv) {
  * @returns {AsyncGenerator<string>} 返回 AsyncGenerator
  */
 async function* openai_stream(raw) {
-  const modelDefault = "gpt-3.5-turbo";
+  const modelDefault = "gemini-2.0-flash";
   const lang = getTargetLanguage("openai");
   let prompt = "";
   if (OJBetter.chatgpt.customPrompt) {
@@ -16751,7 +16751,7 @@ ${raw}
     method: "POST",
     url:
       OJBetter.chatgpt.config.proxy ||
-      "https://api.openai.com/v1/chat/completions",
+      "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
     data: JSON.stringify(data),
     responseType: "stream",
     headers: {

--- a/script/release/nowcoder-better.user.js
+++ b/script/release/nowcoder-better.user.js
@@ -9,7 +9,7 @@
 // @connect      m.youdao.com
 // @connect      translate.google.com
 // @connect      openai.api2d.net
-// @connect      api.openai.com
+// @connect      generativelanguage.googleapis.com
 // @connect      www.luogu.com.cn
 // @connect      greasyfork.org
 // @connect      *
@@ -1360,7 +1360,7 @@ const chatgptConfigEditHTML = `
                 </div>
             </div>
         </label>
-        <input type='text' id='openai_model' placeholder='gpt-3.5-turbo' require = false>
+        <input type='text' id='openai_model' placeholder='gemini-2.0-flash' require = false>
         <label for='openai_key'>
             <div style="display: flex;align-items: center;">
                 <span class="input_label">KEY:</span>
@@ -1388,7 +1388,7 @@ const chatgptConfigEditHTML = `
                 </div>
             </div>
         </label>
-        <input type='text' id='openai_proxy' placeholder='https://api.openai.com/v1/chat/completions' require = false>
+        <input type='text' id='openai_proxy' placeholder='https://generativelanguage.googleapis.com/v1beta/openai/chat/completions' require = false>
         <h5>高级</h5>
         <hr>
         <label for='_header'>
@@ -2344,7 +2344,7 @@ async function translateProblemStatement(text, element_node, button) {
 async function translate_openai(raw) {
     var openai_retext = "";
     var data = {
-        model:  (openai_model !== null && openai_model !== "") ? openai_model : 'gpt-3.5-turbo',
+        model:  (openai_model !== null && openai_model !== "") ? openai_model : 'gemini-2.0-flash',
         messages: [{
             role: "user",
             content: "请将下面的文本翻译为中文，这是一道编程竞赛题描述的一部分，注意术语的翻译，注意保持其中的latex公式不翻译，你只需要回复翻译后的内容即可，不要回复任何其他内容：\n\n" + raw 
@@ -2355,7 +2355,7 @@ async function translate_openai(raw) {
     return new Promise(function (resolve, reject) {
         GM_xmlhttpRequest({
             method: 'POST',
-            url: (openai_proxy !== null && openai_proxy !== "") ? openai_proxy : 'https://api.openai.com/v1/chat/completions',
+            url: (openai_proxy !== null && openai_proxy !== "") ? openai_proxy : 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
 
             data: JSON.stringify(data),
             headers: {


### PR DESCRIPTION
## Summary
- switch API endpoints from OpenAI to Gemini compatible endpoints
- default to `gemini-2.0-flash` model
- update user script connect directives and placeholders

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401985906c8328b781b41c6886e4b8